### PR TITLE
mDNS fixes and changes

### DIFF
--- a/esp8266-web-interface.ino
+++ b/esp8266-web-interface.ino
@@ -780,6 +780,8 @@ void setup(void){
 
   server.begin();
   server.client().setNoDelay(1);
+
+  MDNS.addService("http", "tcp", 80);
 }
  
 void loop(void){

--- a/esp8266-web-interface.ino
+++ b/esp8266-web-interface.ino
@@ -428,6 +428,7 @@ void setup(void){
   updater.setup(&server);
   
   //SERVER INIT
+  ArduinoOTA.setHostname(host);
   ArduinoOTA.begin();
   //list directory
   server.on("/list", HTTP_GET, handleFileList);
@@ -784,4 +785,5 @@ void setup(void){
 void loop(void){
   server.handleClient();
   ArduinoOTA.handle();
+  // note: ArduinoOTA.handle() calls MDNS.update();
 }


### PR DESCRIPTION
## fix the mDNS name so that it properly registers as inverter.local

`mDNS::begin()` is called by our code and also by `ArduinoOTA::begin()`.
It seems that the latest call seems to be the one that "wins".

We call `mDNS::begin()` with our preferred hostname (`inverter`).
Without further configuration, `ArduinoOTA::begin()` would try to re-create
a hostname from "esp8266" and `getChipId()`.

To prevent that, we call `ArduinoOTA::setHostname()` with our preferred hostname
prior to `ArduinoOTA::begin()`.

## adds mDNS service registration for web interface (port 80)

A new `_http._tcp` service is broadcast for port 80. May be discovered
by some browsers with corresponding plugins.

See #13 